### PR TITLE
Upgrade python driver lib for rethinkdb

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-rethinkdb==1.13.0-0
+rethinkdb==1.14.0-0
 Flask==0.9
 requests==1.2.3
 lxml==3.2.1


### PR DESCRIPTION
Performing this upgrade allowed me to import the provided data dump. Before
I was getting an error:

    $ rethinkdb restore -i vim_awesome --force ~/Downloads/rethinkdb_dump_2015-12-15.tar.gz
    Unzipping archive file...
    Done (0 seconds)
    Importing from directory...
    importing with args: ['rethinkdb-import', '--connect', 'localhost:28015', '--directory', '/Users/jeldredge/tmp/tmpcdfdRE', '--auth', '', '--clients', '8', '--import', 'vim_awesome', '--force']
    [                                        ]   0%
    0 rows imported in 7 tables
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    ReQL error during 'import': Unrecognized optional argument `upsert`.
    Errors occurred during import
    Error: rethinkdb-import failed

Some general googling pointed to a possible bug in the python driver having to
do with importing dumps created with different versions of the driver.

I have been using the site with this driver version extensively on my local
machine, including running the various tasks, and have not encountered any issues.