### PR TITLE
Skip vimorg_id assertion

### DIFF
--- a/tools/scrape/build_github_index.py
+++ b/tools/scrape/build_github_index.py
@@ -73,7 +73,11 @@ def get_repos_from_vimorg_descriptions():
             if field in plugin and plugin[field]:
                 repo_urls = set(_extract_github_repo_urls(plugin[field]))
                 vimorg_id = plugin['vimorg_id']
-                assert vimorg_id
+                # TODO(captbaritone) Re-enable this assertion once there is
+                # only one plugin per `vimorg_id`
+                # assert vimorg_id
+                if not vimorg_id:
+                    continue
                 for repo_url in repo_urls:
                     repo_urls_dict[repo_url].add(vimorg_id)
 


### PR DESCRIPTION
When running `make build_github_index` with the provided data dump, I get the
following error:

    PYTHONPATH=. python tools/scrape/build_github_index.py
    Most used plugins: (u'tpope/vim-fugitive', 17411)
    (u'scrooloose/nerdtree', 16987)
    (u'scrooloose/syntastic', 13657)
    (u'kien/ctrlp.vim', 13012)
    (u'tpope/vim-surround', 12305)
    (u'bling/vim-airline', 10767)
    (u'altercation/vim-colors-solarized', 9328)
    (u'gmarik/Vundle.vim', 8709)
    (u'gmarik/vundle', 8643)
    (u'majutsushi/tagbar', 6772)
    Users per manager: Counter({'vundle': 18537, 'pathogen': 10666, 'neobundle':
    5708})
    Plugins per manager: Counter({'vundle': 327750, 'neobundle': 138038,
    'pathogen': 110945})
    Dotfile repos scraped: 75189
    New plugin repos inserted: 0
    Unique plugin bundles found: 14039
    Total plugin bundles found: 576733
    Discovering GitHub repos from vim.org long descriptions ...
    ERROR:root:build_github_index.py: error in <function
    get_repos_from_vimorg_descriptions at 0x10e2119b0>
    Traceback (most recent call last):
    File "tools/scrape/build_github_index.py", line 169, in <module>
        extract_fn()
            File "tools/scrape/build_github_index.py", line 76, in
            get_repos_from_vimorg_descriptions
                assert vimorg_id
                AssertionError

A further investigation shows that in the provided dump 8,676 of the 13,885
plugins have a `null` or empty string set as their `vimorg_id`:

    r.db('vim_awesome').table('plugins').count();
    // Result: 13885

    r.db('vim_awesome').table('plugins').filter({'vimorg_id': null}).count();
    // Result: 8452

    r.db('vim_awesome').table('plugins').filter({'vimorg_id': ''}).count();
    // Result: 224