### PR TITLE
Correctly handle case-insensitive GitHub URLs (Remove duplicates)

### DIFF
--- a/db/github_repos.py
+++ b/db/github_repos.py
@@ -86,6 +86,10 @@ class GithubRepos(object):
         assert owner
         assert repo_name
 
+        # Normalize index values
+        owner = owner.lower()
+        repo_name = repo_name.lower()
+
         query = r.table(cls._TABLE_NAME).get_all([owner, repo_name],
                 index='owner_repo')
         return db.util.get_first(query)
@@ -98,6 +102,10 @@ class GithubRepos(object):
         """
         assert repo['owner']
         assert repo['repo_name']
+
+        # Normalize index values
+        repo['owner'] = repo['owner'].lower()
+        repo['repo_name'] = repo['repo_name'].lower()
 
         if repo.get('id'):
             db_repo = r.table(cls._TABLE_NAME).get(repo['id']).run(r_conn())

--- a/db/migrations/dedupe_github_repo_owner.py
+++ b/db/migrations/dedupe_github_repo_owner.py
@@ -1,0 +1,61 @@
+"""Remove case-sensitive duplicates in GitHub repository tables"""
+
+import rethinkdb as r
+
+import db.plugins
+import db.util
+
+r_conn = db.util.r_conn
+
+
+if __name__ == '__main__':
+    table = 'plugin_github_repos'
+
+    print 'Removing duplicate rows in %s' % table
+
+    updated = 0
+    deleted = 0
+
+    query = r.table(table)
+
+    # Group by the normalized GitHub path
+    query = query.group([
+        r.row['owner'].downcase(),
+        r.row['repo_name'].downcase()])
+
+    # Get the most recently scraped row in each group first
+    query = query.order_by(r.desc('last_scaped_at'))
+
+    grouped_repos = query.run(r_conn())
+
+    for owner_repo, repos in grouped_repos.iteritems():
+
+        print '\nRepo with GitHub path %s occurs %s times' % (
+                owner_repo,
+                len(repos))
+
+        # Use the most recently scraped row as the canonical row
+        canonical = repos.pop()
+
+        assert canonical
+        print 'Using %s as the canoncial row' % canonical['id']
+
+        canonical_owner_repo = (canonical['owner'], canonical['repo_name'])
+
+        if canonical_owner_repo != owner_repo:
+            print "Normalizing %s to %s for our canonical row" % (
+                    canonical_owner_repo,
+                    owner_repo)
+
+            r.table(table).get(canonical['id']).update({
+                'owner': canonical['owner'].lower(),
+                'repo_name': canonical['repo_name'].lower()}).run(r_conn())
+            updated += 1
+
+        if repos:
+            dupe_ids = [dupe['id'] for dupe in repos]
+            print 'Deleting duplicates rows: %s' % ', '.join(dupe_ids)
+            r.table(table).get_all(r.args(dupe_ids)).delete().run(r_conn())
+            deleted += len(repos)
+
+    print "Updated %d rows and deleted %d" % (updated, deleted)

--- a/db/migrations/dedupe_plugin_repo_owner.py
+++ b/db/migrations/dedupe_plugin_repo_owner.py
@@ -1,0 +1,84 @@
+"""Remove case-sensitive duplicates in the plugins table"""
+
+import rethinkdb as r
+
+import db.plugins
+import db.util
+
+r_conn = db.util.r_conn
+
+LOG_FILE = 'deleted_slugs.log'
+
+
+def dupe_log_line(canonical, dupes):
+    return '%s: %s\n' % (canonical, ', '.join(dupes))
+
+
+def merge_plugins(plugins):
+    def reducer(new, old):
+
+        # Use the plugin with the shortest slug as the new plugin
+        if len(old['slug']) < len(new['slug']):
+            new, old = old, new
+
+        new = db.plugins.update_plugin(old, new)
+
+        # Preserve categories
+        if new['category'] == 'uncategorized':
+            new['category'] = old['category']
+
+        # Merge tags
+        new['tags'] = list(set(new['tags'] + old['tags']))
+
+        # Collect the total number of dotfiles referencing this plugin
+        new['github_bundles'] += old['github_bundles']
+
+        return new
+
+    return reduce(reducer, plugins)
+
+if __name__ == '__main__':
+    print 'Removing duplicate rows in plugins. Logging to: %s' % LOG_FILE
+
+    updated = 0
+    deleted = 0
+
+    query = r.table('plugins')
+
+    # Group by the normalized GitHub path
+    query = query.group([
+        r.row['github_owner'].downcase(),
+        r.row['github_repo_name'].downcase()])
+
+    grouped_plugins = query.run(r_conn())
+
+    slug_map = {}
+
+    for owner_repo, plugins in grouped_plugins.iteritems():
+
+        print '\nPlugin with GitHub path %s occurs %s times' % (
+                owner_repo,
+                len(plugins))
+
+        canonical = merge_plugins(plugins)
+
+        print "Using %s as canonical" % canonical['slug']
+
+        # db.plugins.insert normalizes the ower/repo to lower case
+        db.plugins.insert(canonical, conflict='replace')
+        updated += 1
+
+        dupes = [dupe for dupe in plugins if dupe['slug'] != canonical['slug']]
+        if dupes:
+            dupe_slugs = [dupe['slug'] for dupe in dupes]
+            # Store deleted slugs for logging
+            slug_map[canonical['slug']] = dupe_slugs
+            print 'Deleting duplicates rows: %s' % ', '.join(dupe_slugs)
+            r.table('plugins').get_all(r.args(dupe_slugs)).delete().run(r_conn())
+            deleted += len(dupes)
+
+    with open(LOG_FILE, 'w') as log:
+        print 'Writing deleted slug names to %s' % LOG_FILE
+        log.writelines(dupe_log_line(c, d) for c, d in slug_map.iteritems())
+
+    print "Updated %d rows and deleted %d" % (updated, deleted)

--- a/db/plugins.py
+++ b/db/plugins.py
@@ -170,6 +170,10 @@ def insert(plugins, *args, **kwargs):
         if not plugin.get('normalized_name'):
             plugin['normalized_name'] = _normalize_name(plugin)
 
+        # Normalize the GitHub URL properties
+        for key in ['github_owner', 'github_repo_name']:
+            plugin[key] = plugin[key].lower()
+
         mapped_plugins.append(dict(_ROW_SCHEMA, **plugin))
 
     return r.table('plugins').insert(mapped_plugins, *args, **kwargs).run(
@@ -197,33 +201,36 @@ def _generate_unique_slug(plugin):
     #
     # Also this is just wayyyyyyyy more awesome than appending numbers. <3
     slug_suffixes = [
-        'all-too-well',
-        'back-to-december',
-        'better-than-revenge',
-        'come-back-be-here',
-        'enchanted',
-        'everything-has-changed',
-        'fearless',
-        'forever-and-always',
-        'holy-ground',
-        'if-this-was-a-movie',
-        'long-live',
-        'love-story',
-        'mine',
-        'ours',
-        'red',
-        'sad-beautiful-tragic',
-        'safe-and-sound',
-        'shouldve-said-no',
-        'sparks-fly',
-        'speak-now',
-        'state-of-grace',
-        'superman',
-        'sweeter-than-fiction',
-        'the-lucky-one',
-        'the-story-of-us',
-        'treacherous',
-        'you-belong-with-me',
+        'say-im-great',
+        'already-like-death',
+        'he-is-going',
+        'may-fear-less',
+        'are-made-of',
+        'is-written-on',
+        'lives-by-it',
+        'tree-and-truth',
+        'today-cannot-touch',
+        'face-rejection',
+        'hard-things',
+        'please-everybody',
+        'with-ourselves',
+        'frighten-you',
+        'it-has-you',
+        'hands-off',
+        'thing-itself',
+        'the-thing-itself',
+        'impatience-and-laziness',
+        'be-who-we-are',
+        'care-of-itself',
+        'would-can-one',
+        'left-unsaid',
+        'or-are-not',
+        'is-holy',
+        'the-heights',
+        'without-it',
+        'own-character',
+        'who-speaks',
+        'looking-forward',
     ]
     random.shuffle(slug_suffixes)
 
@@ -412,8 +419,12 @@ def _find_matching_plugins(plugin_data, repo=None):
     # If we have a (github_owner, github_repo_name) pair, try to match it with
     # an existing github-scraped plugin.
     if plugin_data.get('github_owner') and plugin_data.get('github_repo_name'):
+        github_owner_repo = [
+            plugin_data['github_owner'].lower(),
+            plugin_data['github_repo_name'].lower()]
+
         query = r.table('plugins').get_all(
-                [plugin_data['github_owner'], plugin_data['github_repo_name']],
+                github_owner_repo,
                 index='github_owner_repo')
         matching_plugins = list(query.run(r_conn()))
         if matching_plugins:
@@ -470,8 +481,8 @@ def _are_plugins_different(p1, p2):
 
     if (p1.get('github_owner') and p1.get('github_repo_name') and
             p2.get('github_owner') and p2.get('github_repo_name') and
-            (p1['github_owner'], p1['github_repo_name']) !=
-            (p2['github_owner'], p2['github_repo_name'])):
+            (p1['github_owner'].lower(), p1['github_repo_name'].lower()) !=
+            (p2['github_owner'].lower(), p2['github_repo_name'].lower())):
         return True
 
     return False

--- a/test/db/migrations/dedupe_plugin_repo_owner_test.py
+++ b/test/db/migrations/dedupe_plugin_repo_owner_test.py
@@ -1,0 +1,78 @@
+import unittest
+import itertools
+from db.migrations.dedupe_plugin_repo_owner import merge_plugins
+
+
+def dummy_plugin(**kwargs):
+    default = {
+            'slug': 'slug',
+            'category': 'uncategorized',
+            'tags': [],
+            'github_bundles': 0,
+            'vimorg_id': None}
+
+    for key, value in kwargs.iteritems():
+        default[key] = value
+
+    return default
+
+
+class MergePluginsTest(unittest.TestCase):
+
+    def _test_merge(self, plugins, expected):
+        """ Assert that a list of plugins will get merged into `expected`
+        independent of order """
+
+        # For every permutation ...
+        for plugins_perm in itertools.permutations(plugins):
+            actual = merge_plugins(plugins_perm)
+            self.assertEquals(actual['slug'], expected['slug'])
+            self.assertEquals(actual['category'], expected['category'])
+            self.assertItemsEqual(actual['tags'], expected['tags'])
+            self.assertEqual(actual['github_bundles'], expected['github_bundles'])
+            self.assertEqual(actual['vimorg_id'], expected['vimorg_id'])
+
+    def test_preserves_category(self):
+        plugins = [
+            dummy_plugin(),
+            dummy_plugin(category='color')]
+
+        expected = dummy_plugin(category='color')
+
+        self._test_merge(plugins, expected)
+
+    def test_preserves_shortes_slug(self):
+        plugins = [
+            dummy_plugin(slug='short-slug'),
+            dummy_plugin(slug='medium-slug'),
+            dummy_plugin(slug='much-longer-slug')]
+
+        expected = dummy_plugin(slug='short-slug')
+        self._test_merge(plugins, expected)
+
+    def test_merges_tags(self):
+        plugins = [
+            dummy_plugin(tags=['a', 'b', 'c']),
+            dummy_plugin(tags=[]),
+            dummy_plugin(tags=['z'])]
+
+        expected = dummy_plugin(tags=['a', 'b', 'c', 'z'])
+        self._test_merge(plugins, expected)
+
+    def test_collects_github_bundles(self):
+        plugins = [
+            dummy_plugin(github_bundles=1),
+            dummy_plugin(github_bundles=0),
+            dummy_plugin(github_bundles=8),
+            dummy_plugin(github_bundles=8)]
+
+        expected = dummy_plugin(github_bundles=17)
+        self._test_merge(plugins, expected)
+
+    def test_preserves_vimorg_id(self):
+        plugins = [
+            dummy_plugin(vimorg_id=None),
+            dummy_plugin(vimorg_id="1234")]
+
+        expected = dummy_plugin(vimorg_id="1234")
+        self._test_merge(plugins, expected)

--- a/test/db/plugins_test.py
+++ b/test/db/plugins_test.py
@@ -98,11 +98,11 @@ class PluginsTest(unittest.TestCase):
                 {'github_owner': 'tpope', 'github_repo_name': 'bbq'},
                 {'github_owner': 'sjl', 'github_repo_name': 'bbq'}))
         self.assertTrue(diff(
-                {'vimorg_id': 1, 'github_owner': 2, 'github_repo_name': 2},
-                {'vimorg_id': 1, 'github_owner': 3, 'github_repo_name': 3}))
+                {'vimorg_id': 1, 'github_owner': 'foo', 'github_repo_name': 'foo'},
+                {'vimorg_id': 1, 'github_owner': 'bar', 'github_repo_name': 'bar'}))
         self.assertTrue(diff(
-                {'vimorg_id': 2, 'github_owner': 1, 'github_repo_name': 1},
-                {'vimorg_id': 3, 'github_owner': 1, 'github_repo_name': 1}))
+                {'vimorg_id': 2, 'github_owner': 'foo', 'github_repo_name': 'bar'},
+                {'vimorg_id': 3, 'github_owner': 'foo', 'github_repo_name': 'bar'}))
 
         self.assertFalse(diff({}, {}))
         self.assertFalse(diff({'vimorg_id': 1}, {}))
@@ -117,3 +117,6 @@ class PluginsTest(unittest.TestCase):
                 {'github_owner': 'sjl', 'github_repo_name': 'Gundo'}))
         self.assertFalse(diff({'vimorg_id': 1},
                 {'github_owner': 'sjl', 'github_repo_name': 'Gundo'}))
+        self.assertFalse(diff(
+                {'github_owner': 'VundleVim', 'github_repo_name': 'Vundle.vim'},
+                {'github_owner': 'vundlevim', 'github_repo_name': 'vundle.vim'}))

--- a/tools/scrape/build_github_index.py
+++ b/tools/scrape/build_github_index.py
@@ -128,6 +128,8 @@ def aggregate_repos_from_dotfiles():
             manager_counter[manager] += len(plugin_repos)
 
             for owner_repo in plugin_repos:
+                # Normalize the GitHub URL fragment
+                owner_repo = owner_repo.lower()
                 repos_counter[owner_repo] += 1
 
     num_inserted = 0

--- a/tools/scrape/github.py
+++ b/tools/scrape/github.py
@@ -298,8 +298,7 @@ def scrape_plugin_repos(num):
                 'repo_name': repo_data['parent']['name'],
             })
 
-        r.table('plugin_github_repos').insert(repo,
-                conflict='replace').run(r_conn())
+        PluginGithubRepos.upsert_with_owner_repo(repo)
 
         # For most cases we don't care about forked repos, unless the forked
         # repo is used by others.


### PR DESCRIPTION
Depends on: #78, #79
Fixes: #74, #72, #68, #64
 
GitHub's owner and repository names are case insensitive, but we were
determining uniqueness by directly comparing strings. The result is we've
collected a bunch of duplicate data.

Unfortunately our "write-only" approach to maintaining our data means that
simply correcting our scraping will not clean up the duplicate data. Instead we
need to pro actively remove the duplicates in our tables. To that end I have
created two migrations which perform this task. They should be run in this
order:

    # Remove dupes from the `plugin_github_repos` table
    python db/migrations/dedupe_github_repo_owner.py

    # Correct our `plugin_manager_users` counts
    make build_github_index

    # Remove dupes from the `plugins` table
    python db/migrations/dedupe_plugin_repo_owner

I could not find an existing method to pro actively push the
`plugin_manager_count` from `plugin_github_repos` to the `github_bundles`
fields in `plugins`, but our scrapping cron jobs should get us back in sync
eventually.

Questions
---------

1. Are we discarding an association between vimorg and plugins?
2. Is it okay to sacrifice (and possibly reuse) the permalinks of the duplicate
   plugin entries we will delete?

Further work
------------

There are at least one other class of duplicate plugins. Plugins that were
generated from github repositories which were later renames. In this case we
update the `plugin_github_repos` table, but never proactively clean the
`plugins` table (as far as I can tell).