### PR TITLE
Fix top margin of long desciption (fixes #77)

### DIFF
--- a/web/static/sass/screen.scss
+++ b/web/static/sass/screen.scss
@@ -879,6 +879,7 @@ $long-desc-bg: #FBFBFB;
   background: mix($bg-light-2, $bg-light-1, 40%);
   @include box-shadow(0 1px 1px rgba(black, 0.1));
   background: $long-desc-bg;
+  display: inline-block;
 }
 
 .long-desc {


### PR DESCRIPTION
Tested on modern versions of Chrome, Firefox and Safari on OSX

## Before:

<img width="1387" alt="screen shot 2016-03-04 at 9 52 38 pm" src="https://cloud.githubusercontent.com/assets/162735/13545987/71394052-e253-11e5-8a0c-77ef020d534e.png">

## After:

<img width="1387" alt="screen shot 2016-03-04 at 9 51 56 pm" src="https://cloud.githubusercontent.com/assets/162735/13545985/61be2a2a-e253-11e5-8548-aa8a0cd0eb68.png">
