### PR TITLE
Enable travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+    - "2.7"
+install:
+    - pip install -r requirements.txt
+script: 
+    - make test

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ build_github_index:
 
 test:
 	tox
+	npm run lint
 
 upgrade_deps:
 	pip-compile --upgrade requirements.in --output-file requirements.txt


### PR DESCRIPTION
For this to be useful, we will need to enable the Travis web hook in GitHub's settings. I don't have access to those settings.

@divad12 