### PR TITLE
Allow upserting plugins without github info

### DIFF
--- a/db/plugins.py
+++ b/db/plugins.py
@@ -164,22 +164,26 @@ def insert(plugins, *args, **kwargs):
 
     mapped_plugins = []
     for plugin in plugins:
-        if not plugin.get('slug'):
-            plugin['slug'] = _generate_unique_slug(plugin)
-
-        if not plugin.get('normalized_name'):
-            plugin['normalized_name'] = _normalize_name(plugin)
-
-        # Normalize the GitHub URL properties
-        for key in ['github_owner', 'github_repo_name']:
-            # Vim.org plugins don't have GitHub info
-            if key in plugin:
-                plugin[key] = plugin[key].lower()
+        _normalize(plugin)
 
         mapped_plugins.append(dict(_ROW_SCHEMA, **plugin))
 
     return r.table('plugins').insert(mapped_plugins, *args, **kwargs).run(
             r_conn())
+
+
+def _normalize(plugin):
+    if not plugin.get('slug'):
+        plugin['slug'] = _generate_unique_slug(plugin)
+
+    if not plugin.get('normalized_name'):
+        plugin['normalized_name'] = _normalize_name(plugin)
+
+    # Normalize the GitHub URL properties
+    for key in ['github_owner', 'github_repo_name']:
+        # Vim.org plugins don't have GitHub info
+        if key in plugin:
+            plugin[key] = plugin[key].lower()
 
 
 def _generate_unique_slug(plugin):

--- a/db/plugins.py
+++ b/db/plugins.py
@@ -172,7 +172,9 @@ def insert(plugins, *args, **kwargs):
 
         # Normalize the GitHub URL properties
         for key in ['github_owner', 'github_repo_name']:
-            plugin[key] = plugin[key].lower()
+            # Vim.org plugins don't have GitHub info
+            if key in plugin:
+                plugin[key] = plugin[key].lower()
 
         mapped_plugins.append(dict(_ROW_SCHEMA, **plugin))
 

--- a/test/db/plugins_test.py
+++ b/test/db/plugins_test.py
@@ -26,6 +26,34 @@ class PluginsTest(unittest.TestCase):
         assert_update({}, {'created_at': 5}, {'created_at': 5})
         assert_update({'created_at': 1}, {'created_at': 5}, {'created_at': 1})
 
+    def test_normalize_fixes_github_case(self):
+        actual_plugin = {
+            'vimorg_name': 'A Plugin',
+            'github_owner': 'TPope',
+            'github_repo_name': 'FUgiTive'}
+
+        db.plugins._normalize(actual_plugin)
+
+        expected = {
+            'github_owner': 'tpope',
+            'github_repo_name': 'fugitive',
+            'vimorg_name': 'A Plugin',
+            'normalized_name': 'aplugin',
+            'slug': 'a-plugin'}
+
+        self.assertEquals(actual_plugin, expected)
+
+    def test_normalize_without_github_repo(self):
+        actual_plugin = {'vimorg_name': 'A Plugin'}
+        db.plugins._normalize(actual_plugin)
+
+        expected = {
+            'vimorg_name': 'A Plugin',
+            'normalized_name': 'aplugin',
+            'slug': 'a-plugin'}
+
+        self.assertEquals(actual_plugin, expected)
+
     def test_merge_dict_except_none(self):
         merge = db.plugins._merge_dict_except_none
 


### PR DESCRIPTION
My fix for GitHub case insensitivity (#80) made the incorrect assumption that
all plugins had GitHub info. This is not true. For plugins scrapped from
vim.org, we leave the github owner and repo name blank.

Currently the vim.org scrape task is broken with errors that look like:

    Scraping plugins from vim.org...
    /Library/Python/2.7/site-packages/html5lib/ihatexml.py:262: DataLossWarning: Coercing non-XML name
    warnings.warn("Coercing non-XML name", DataLossWarning)
        scraping license-to-vim (vimorg_id=5349) ...ERROR:root:
    Error scraping license-to-vim (vimorg_id=5349) from vim.org
    Traceback (most recent call last):
    File "/Users/jeldredge/cloud/projects/vim-awesome/tools/scrape/vimorg.py", line 73, in scrape_scripts
        db.plugins.add_scraped_data(plugin, submission=submission)
    File "/Users/jeldredge/cloud/projects/vim-awesome/db/plugins.py", line 526, in add_scraped_data
        insert(plugin_data)
    File "/Users/jeldredge/cloud/projects/vim-awesome/db/plugins.py", line 175, in insert
        plugin[key] = plugin[key].lower()
    KeyError: 'github_owner'