### PR TITLE
Switch to tox for Python testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.py[co]
+.tox/
 .sass-cache/
 db/rethinkdb_data/
 node_modules/

--- a/Makefile
+++ b/Makefile
@@ -36,10 +36,7 @@ build_github_index:
 	PYTHONPATH=. python tools/scrape/build_github_index.py
 
 test:
-	PYTHONPATH=. nosetests -v
-
-lint:
-	PYTHONPATH=. flake8 --ignore=E128,E121,E126,E501,E127,E122,E131,E731 .
+	tox
 
 upgrade_deps:
 	pip-compile --upgrade requirements.in --output-file requirements.txt

--- a/requirements.in
+++ b/requirements.in
@@ -17,7 +17,5 @@ configparser==3.5.0b2
 # For generating human-friendly and URL-friendly slugs
 python-slugify==0.0.6
 
-# Dev tools. Consider splitting this out to a separate file if there get to be
-# too may
-flake8==2.5.0
-nose==1.1.2
+# Dev and testing. TODO: split these out into their own requirements files.
+tox

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,17 +5,14 @@
 #    pip-compile requirements.in
 #
 configparser==3.5.0b2
-flake8==2.5.0
 Flask-Cache==0.12
 Flask==0.9                # via flask-cache
 html5lib==1.0b1
 Jinja2==2.8               # via flask
 lxml==3.5.0
 MarkupSafe==0.23          # via jinja2
-mccabe==0.3.1             # via flake8
-nose==1.1.2
-pep8==1.7.0               # via flake8
-pyflakes==1.0.0           # via flake8
+pluggy==0.3.1             # via tox
+py==1.4.31                # via tox
 python-dateutil==2.5.0
 python-slugify==0.0.6
 PyYAML==3.11
@@ -23,5 +20,7 @@ requests==1.2.3
 rethinkdb==1.14.0-0
 six==1.10.0               # via html5lib, python-dateutil
 termcolor==1.1.0
+tox==2.3.1
 Unidecode==0.4.19         # via python-slugify
+virtualenv==15.0.1        # via tox
 Werkzeug==0.11.4          # via flask

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,16 @@
+[tox]
+envlist = py27,pep8
+skipsdist = True
+
+[testenv]
+deps = 
+    mock
+    nose
+    -r{toxinidir}/requirements.txt
+setenv =
+    PYTHONPATH = {toxinidir}
+commands = nosetests -v
+
+[testenv:pep8]
+deps = flake8
+commands = flake8 --ignore=E128,E121,E126,E501,E127,E122,E131,E731 .


### PR DESCRIPTION
[`tox`](https://testrun.org/tox/latest/) is Python tool that makes testing Python applications under different environments much easier and is generally viewed as (one of) the best ways to test Python code. This switch lays the groundwork to begin testing across different Python (and library dependency) versions in the future.

In making this switch:

- The `make test` command is updated to use the new `tox` setup.
- The `make lint` command is removed in favor of `tox` handling
  `flake8` execution.
- Test dependencies are removed from `requirements.in` and `requirements.txt` and included in `tox.ini` instead.

----

@captbaritone If / when this and #91 get merged, I'll also submit a change to allow travis to test all tox environments in parallel.