### PR TITLE
Add support for Sentry

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,3 +1,4 @@
+raven[flask]
 rethinkdb==1.14.0-0
 Flask==0.9
 requests>=1.2.3,<2.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,9 +4,11 @@
 #
 #    pip-compile requirements.in
 #
+blinker==1.4              # via raven
 configparser==3.5.0b2
+contextlib2==0.5.1        # via raven
 Flask-Cache==0.12
-Flask==0.9                # via flask-cache
+Flask==0.9                # via flask-cache, raven
 html5lib==1.0b1
 Jinja2==2.8               # via flask
 lxml==3.5.0
@@ -16,6 +18,7 @@ py==1.4.31                # via tox
 python-dateutil==2.5.0
 python-slugify==0.0.6
 PyYAML==3.11
+raven[flask]==5.12.0
 requests==1.2.3
 rethinkdb==1.14.0-0
 six==1.10.0               # via html5lib, python-dateutil

--- a/secrets.py.example
+++ b/secrets.py.example
@@ -18,5 +18,8 @@ GITHUB_PERSONAL_ACCESS_TOKEN = "lalalalalalimnottellingyou"
 HIPCHAT_ROOM_ID = 13
 HIPCHAT_TOKEN = "itwasrareiwasthere"
 
+# For logging exceptions to Sentry
+SENTRY_DSN = None
+
 # Shh, don't let the NSA know we have this.
 US_NUCLEAR_LAUNCH_CODE = "00000000"

--- a/web/server.py
+++ b/web/server.py
@@ -2,6 +2,7 @@ import logging
 
 import flask
 from cache import cache
+from raven.contrib.flask import Sentry
 
 import db
 import web.api.api as api
@@ -11,9 +12,11 @@ try:
     import secrets
     _HIPCHAT_TOKEN = secrets.HIPCHAT_TOKEN
     _HIPCHAT_ROOM_ID = secrets.HIPCHAT_ROOM_ID
+    _SENTRY_DSN = secrets.SENTRY_DSN
 except ImportError:
     _HIPCHAT_TOKEN = None
     _HIPCHAT_ROOM_ID = None
+    _SENTRY_DSN = None
 
 r_conn = db.util.r_conn
 
@@ -22,6 +25,8 @@ app = flask.Flask(__name__)
 app.config.from_envvar('FLASK_CONFIG')
 app.register_blueprint(api.api)
 cache.init_app(app)
+# Initialize the Sentry plugin
+Sentry(app, dsn=_SENTRY_DSN)
 
 
 # Add logging handlers on the production server.


### PR DESCRIPTION
Add raven and its dependencies as requirements, add a placeholder for
``SENTRY_DSN``, and initialize the plugin on the Flask application. If
no DSN is provided, the plugin remains registered but does not attempt
to contact a remote Sentry server.

Fixes #110.