### PR TITLE
Add simple jest test for component render

### DIFF
--- a/conf/jest_preprocessor.js
+++ b/conf/jest_preprocessor.js
@@ -1,0 +1,11 @@
+var ReactTools = require('react-tools');
+
+module.exports = {
+  process: function(src, path) {
+    if (/\.jsx$/.test(path)) {
+      src = ReactTools.transform(src, {harmony: true});
+      return src;
+    }
+    return src;
+  },
+};

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
     "jsx-loader": "~0.10.2",
+    "react-tools": "^0.10.0",
     "webpack": "~1.3.1-beta4"
   },
   "dependencies": {
+    "jest-cli": "^0.10.0",
     "jquery": "~2.1.1",
     "marked": "~0.3.2",
     "moment": "~2.12.0",
@@ -21,6 +23,16 @@
     "underscore": "~1.8.3"
   },
   "scripts": {
-    "lint": "eslint --ext js,jsx ."
+    "lint": "eslint --ext js,jsx .",
+    "test": "jest"
+  },
+  "jest": {
+    "automock": false,
+    "rootDir": "web/static/js",
+    "scriptPreprocessor": "../../../conf/jest_preprocessor.js",
+    "testFileExtensions": [
+      "js",
+      "jsx"
+    ]
   }
 }

--- a/web/static/js/__tests__/SidebarCategory-test.jsx
+++ b/web/static/js/__tests__/SidebarCategory-test.jsx
@@ -1,0 +1,32 @@
+/** @jsx React.DOM */
+
+var React = require('react');
+
+var SidebarCategory = require('../SidebarCategory.jsx');
+
+var TEST_CATEGORY = {
+  "description": "Plugins and color schemes that enhance code display",
+  "icon": "icon-code",
+  "id": "code-display",
+  "name": "Code display",
+  "tags": [
+    {
+      "count": 15,
+      "id": "color-scheme",
+    },
+    {
+      "count": 5,
+      "id": "dark",
+    },
+  ],
+};
+
+describe('SidebarCategory', function() {
+  it('renders without throwing', function() {
+    var container = document.createElement('div');
+    React.renderComponent(
+      <SidebarCategory category={TEST_CATEGORY} selectedTags={[]} />,
+      container
+    );
+  });
+});


### PR DESCRIPTION
react-tools is deprecated but in webpack we're already using jsx-loader, which uses react-tools, so I'm using the same for compatibility. I added this test because it's simple and isolated but as app.jsx is broken up more, it should be easy to add new tests.

Test Plan: `npm test`