### PR TITLE
Use node 4.0 in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
     - "2.7"
 install:
     - pip install -r requirements.txt
+    - nvm install 4.0 && nvm 4.0
     - npm install
 script: 
     - make test


### PR DESCRIPTION
As of #123, `npm install` crashes on versions of node < 4