### PR TITLE
Clarify dev and prod npm packages (don't install jest in prod)

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,19 +8,19 @@
   "devDependencies": {
     "eslint": "^2.4.0",
     "eslint-plugin-react": "^4.2.3",
-    "jsx-loader": "~0.10.2",
-    "react-tools": "^0.10.0",
-    "webpack": "~1.3.1-beta4"
+    "jest-cli": "^0.10.0",
+    "react-tools": "^0.10.0"
   },
   "dependencies": {
-    "jest-cli": "^0.10.0",
     "jquery": "~2.1.1",
+    "jsx-loader": "~0.10.2",
     "marked": "~0.3.2",
     "moment": "~2.12.0",
     "react": "~0.10.0",
     "react-nested-router": "~0.2.0",
     "store": "~1.3.16",
-    "underscore": "~1.8.3"
+    "underscore": "~1.8.3",
+    "webpack": "~1.3.1-beta4"
   },
   "scripts": {
     "lint": "eslint --ext js,jsx .",

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -26,7 +26,7 @@ echo "Installing Python requirements"
 sudo pip install -r $NEW_CLONE/requirements.txt
 
 echo "Installing Node requirements"
-( cd $NEW_CLONE && npm install )
+( cd $NEW_CLONE && npm install --only=production)
 
 echo "Installing Ruby requirements"
 ( cd $NEW_CLONE && bundle install )


### PR DESCRIPTION
The main goal here is to not install jest on prod.

Jest needs node >= 4, but it's not easy to get node > v0.10.25 via apt-get.

I've separated the dependencies into things that are needed in order to build
the production bundle and those that are not.