### PR TITLE
Transfer repo to an org! github.com/divad12 --> github.com/vim-awesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ repos on GitHub, it is still a useful source of relative usage data.
   $ make init_db
   ```
 
-1. Seed the database with some test data. Download [this database dump](https://github.com/divad12/vim-awesome/releases/download/v1.1/rethinkdb_dump_2016-03-08.tar.gz), and then run
+1. Seed the database with some test data. Download [this database dump](https://github.com/vim-awesome/vim-awesome/releases/download/v1.1/rethinkdb_dump_2016-03-08.tar.gz), and then run
 
 
   ```sh
@@ -78,9 +78,9 @@ repos on GitHub, it is still a useful source of relative usage data.
 
 ## Contributing
 
-Take a look at [some of these issues](https://github.com/divad12/vim-awesome/issues?labels=easyfix&state=open) to get started.
+Take a look at [some of these issues](https://github.com/vim-awesome/vim-awesome/issues?labels=easyfix&state=open) to get started.
 
-Chat with us on [Gitter](https://gitter.im/divad12/vim-awesome)!
+Chat with us on [Gitter](https://gitter.im/vim-awesome/vim-awesome)!
 
 ## Acknowledgements
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "repository": {
     "type": "git",
-    "url": "git://github.com/divad12/vim-awesome.git"
+    "url": "git://github.com/vim-awesome/vim-awesome.git"
   },
   "devDependencies": {
     "eslint": "^2.4.0",

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -19,7 +19,7 @@ NEW_CLONE=repos/vim-awesome-`date +%s`
 
 # Do the clone
 echo "Cloning vim-awesome"
-git clone git@github.com:divad12/vim-awesome.git $NEW_CLONE > /dev/null
+git clone git@github.com:vim-awesome/vim-awesome.git $NEW_CLONE > /dev/null
 
 # TODO(david): Use virtualenv so we don't have to sudo pip install
 echo "Installing Python requirements"

--- a/web/static/js/AboutPage.jsx
+++ b/web/static/js/AboutPage.jsx
@@ -69,7 +69,7 @@ var AboutPage = React.createClass({
           <ul>
             <li>
               Tackle a{' '}
-              <a href="https://github.com/divad12/vim-awesome/issues?labels=easyfix&amp;state=open">
+              <a href="https://github.com/vim-awesome/vim-awesome/issues?labels=easyfix&amp;state=open">
                 starter issue on GitHub
               </a> (or report an issue!).
             </li>

--- a/web/static/js/Footer.jsx
+++ b/web/static/js/Footer.jsx
@@ -28,7 +28,7 @@ var Footer = React.createClass({
           </div>
         </div>
         <div className="github-section">
-          <a href="https://github.com/divad12/vim-awesome"
+          <a href="https://github.com/vim-awesome/vim-awesome"
               className="github-link">
             Contribute
             <i className="icon-github"></i>


### PR DESCRIPTION
The organization has been set up! http://github.com/vim-awesome

@captbaritone Review please?

Anything else we want to do before pulling the trigger to transfer to the new org? Here's what I can think of:

- [ ] merge this in
- [ ] transfer to vim-awesome org
- [ ] update server's git repo to point to the new one
- [ ] update Gitter chat room?

I think GitHub will automatically redirect the old url to the new one, so that should take care of a lot of potential issues.